### PR TITLE
The upper bound on z should always be at least 0

### DIFF
--- a/src/omlt/gbt/formulation.py
+++ b/src/omlt/gbt/formulation.py
@@ -86,7 +86,7 @@ def add_formulation_to_block(block, model_definition, input_vars, output_vars):
     block.x = pe.Var(categorical_index(), domain=pe.Binary)
 
     block.z_l = pe.Var(
-        zip(nodes_tree_ids[nodes_leaf_mask], nodes_node_ids[nodes_leaf_mask]),
+        list(zip(nodes_tree_ids[nodes_leaf_mask], nodes_node_ids[nodes_leaf_mask])),
         bounds=(0, None),
         domain=pe.Reals,
     )

--- a/src/omlt/neuralnet/relu.py
+++ b/src/omlt/neuralnet/relu.py
@@ -102,7 +102,8 @@ def build_relu_mip_formulation(block, network_structure, M=None):
             block._big_m_lb[i] = -M
 
         if ub is not None:
-            block.z[i].setub(ub)
+            # the upper bound should always be at least 0
+            block.z[i].setub(max(ub, 0))
             # use upper bound on z as big-m
             block._big_m_ub[i] = ub
         else:


### PR DESCRIPTION
In some cases, it is possible to compute an upper bound on `zhat` that is strictly negative. In such cases, setting the upper bound on `z` to be equal to the upper bound on `zhat` is incorrect and produces an infeasible model. Even if `zhat` is strictly negative, `z` can still be `0`.