### PR TITLE
add dependencies to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ install_requires =
     importlib-metadata; python_version<"3.8"
     networkx
     pyomo
+    numpy
 
 
 [options.packages.find]


### PR DESCRIPTION
this adds numpy to the omlt dependencies. 

should we also add onnx? The onnx reader requires it. Otherwise the user will just get an error.

same for tensorflow. we now use `tensorflow.keras` to read a keras sequential model. I don't think it should be a dependency, but maybe a more descriptive error when they try to use the keras reader?