### PR TITLE
Add GBT base score to block output

### DIFF
--- a/docs/notebooks/bo_with_trees.ipynb
+++ b/docs/notebooks/bo_with_trees.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Bayesian Optimization with Trees in OMLT\n",
     "\n",
-    "This notebook introduces the `OMLT` gradient-boosted trees (GBT) functionality and how `OMLT` incorporates such models in a Bayesian optimization loop. For a more comprehensive framework using GBT models for Bayesian optimization, please check out another project of our group: [ENTMOOT](https://github.com/cog-imperial/entmoot)."
+    "This notebook introduces the `OMLT` gradient-boosted trees (GBT) functionality and how `OMLT` incorporates such models in a Bayesian optimization loop. `OMLT` currently supports `ONNX` imports from `lightgbm` and `sklearn`. For a more comprehensive framework using GBT models for Bayesian optimization, please check out another project of our group: [ENTMOOT](https://github.com/cog-imperial/entmoot)."
    ]
   },
   {
@@ -485,7 +485,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.11"
   }
  },
  "nbformat": 4,

--- a/src/omlt/gbt/gbt_formulation.py
+++ b/src/omlt/gbt/gbt_formulation.py
@@ -108,6 +108,10 @@ def add_formulation_to_block(block, model_definition, input_vars, output_vars):
     root_node = graph.node[0]
     attr = _node_attributes(root_node)
 
+    # base_values don't apply to lgbm models
+    base_value = np.array(attr["base_values"].floats)[0] \
+        if "base_values" in attr else 0.0
+
     nodes_feature_ids = np.array(attr["nodes_featureids"].ints)
     nodes_values = np.array(attr["nodes_values"].floats)
     nodes_modes = np.array(attr["nodes_modes"].strings)
@@ -318,7 +322,7 @@ def add_formulation_to_block(block, model_definition, input_vars, output_vars):
             for tree_id, node_id, weight in zip(
                 target_tree_ids, target_node_ids, target_weights
             )
-        )
+        ) + base_value
 
 
 def _node_attributes(node):


### PR DESCRIPTION
**Legal Acknowledgement**
By contributing to this software project, I agree my contributions are submitted under the BSD license.
I represent I am authorized to make the contributions and grant the license.
If my employer has rights to intellectual property that includes these contributions,
I represent that I have received permission to make contributions and grant the required license on behalf of that employer.

This PR addresses #80. GBT models imported from scikit-learn have an additional constant base score that is added to the prediction of the model. This doesn't apply for lightgbm and the base score defaults to zero. I also added a note to the jupyter notebook that only lightgbm and scikit-learn tree model inputs are officially supported.