### PR TITLE
Fix missing dependencies in notebooks

### DIFF
--- a/docs/notebooks/neuralnet/auto-thermal-reformer-relu.ipynb
+++ b/docs/notebooks/neuralnet/auto-thermal-reformer-relu.ipynb
@@ -50,7 +50,10 @@
     "- `pandas`: used for data import and management <br>\n",
     "- `tensorflow`: the machine learning language we use to train our neural network\n",
     "- `pyomo`: the algebraic modeling language for Python, it is used to define the optimization model passed to the solver\n",
-    "- `omlt`: The package this notebook demonstates. OMLT can formulate machine learning models (such as neural networks) within Pyomo"
+    "- `onnx`: used to express trained neural network models\n",    
+    "- `omlt`: The package this notebook demonstates. OMLT can formulate machine learning models (such as neural networks) within Pyomo\n",
+    "\n",
+    "**NOTE:** This notebook also assumes you have a working MIP solver executable (e.g., CBC, Gurobi) to solve optimization problems in Pyomo. The open-source solver CBC is called by default."
    ]
   },
   {

--- a/docs/notebooks/neuralnet/auto-thermal-reformer.ipynb
+++ b/docs/notebooks/neuralnet/auto-thermal-reformer.ipynb
@@ -50,7 +50,10 @@
     "- `pandas`: used for data import and management <br>\n",
     "- `tensorflow`: the machine learning language we use to train our neural network\n",
     "- `pyomo`: the algebraic modeling language for Python, it is used to define the optimization model passed to the solver\n",
-    "- `omlt`: The package this notebook demonstates. OMLT can formulate machine learning models (such as neural networks) within Pyomo"
+    "- `onnx`: used to express trained neural network models\n",    
+    "- `omlt`: The package this notebook demonstates. OMLT can formulate machine learning models (such as neural networks) within Pyomo\n",
+    "\n",
+    "**NOTE:** This notebook also assumes you have a working MIP solver executable (e.g., CBC, Gurobi) to solve optimization problems in Pyomo. The open-source solver IPOPT is called by default."
    ]
   },
   {

--- a/docs/notebooks/neuralnet/mnist_example_convolutional.ipynb
+++ b/docs/notebooks/neuralnet/mnist_example_convolutional.ipynb
@@ -25,6 +25,7 @@
     "- `torch`: the machine learning language we use to train our neural network\n",
     "- `torchvision`: a package containing the MNIST dataset\n",
     "- `pyomo`: the algebraic modeling language for Python, it is used to define the optimization model passed to the solver\n",
+    "- `onnx`: used to express trained neural network models\n",    
     "- `omlt`: the package this notebook demonstates. OMLT can formulate machine learning models (such as neural networks) within Pyomo\n",
     "\n",
     "**NOTE:** This notebook also assumes you have a working MIP solver executable (e.g., CBC, Gurobi) to solve optimization problems in Pyomo. The open-source solver CBC is called by default."

--- a/docs/notebooks/neuralnet/mnist_example_dense.ipynb
+++ b/docs/notebooks/neuralnet/mnist_example_dense.ipynb
@@ -24,6 +24,7 @@
     "- `torch`: the machine learning language we use to train our neural network\n",
     "- `torchvision`: a package containing the MNIST dataset\n",
     "- `pyomo`: the algebraic modeling language for Python, it is used to define the optimization model passed to the solver\n",
+    "- `onnx`: used to express trained neural network models\n",    
     "- `omlt`: the package this notebook demonstates. OMLT can formulate machine learning models (such as neural networks) within Pyomo\n",
     "\n",
     "**NOTE:** This notebook also assumes you have a working MIP solver executable (e.g., CBC, Gurobi) to solve optimization problems in Pyomo. The open-source solver CBC is called by default."

--- a/docs/notebooks/neuralnet/neural_network_formulations.ipynb
+++ b/docs/notebooks/neuralnet/neural_network_formulations.ipynb
@@ -34,7 +34,10 @@
     "- `matplotlib`: used for plotting the results in this example\n",
     "- `tensorflow`: the machine learning language we use to train our neural network\n",
     "- `pyomo`: the algebraic modeling language for Python, it is used to define the optimization model passed to the solver\n",
-    "- `omlt`: The package this notebook demonstates. OMLT can formulate machine learning models (such as neural networks) within Pyomo"
+    "- `onnx`: used to express trained neural network models\n",
+    "- `omlt`: The package this notebook demonstates. OMLT can formulate machine learning models (such as neural networks) within Pyomo\n",
+    "\n",
+    "**NOTE:** This notebook also assumes you have a working MIP solver executable (e.g., CBC, Gurobi) to solve optimization problems in Pyomo. The open-source solvers CBC and IPOPT are called by default."
    ]
   },
   {


### PR DESCRIPTION
@tsaycal @jalving Here are the remaining changes I think need to be made so the notebooks run correctly; I've put them in a pull request because it was getting a bit confusing on the Slack. With these changes added (and the solvers installed as per the "NOTE"s in the notebooks), everything runs correctly. 
**NB** These are the changes needed with OMLT installed from source instead of PyPI - there are still a couple of missing dependencies when building from source. 
@tsaycal I saw you had made a commit removing onnx from neural_network_formulations. I tried running the notebook in an environment with OMLT built from source but without onnx directly installed. However, there was still a ModuleNotFoundError. I have added it back as a dependency but can remove it from this pull request if that is incorrect.


**Legal Acknowledgement**\
By contributing to this software project, I agree my contributions are submitted under the BSD license. 
I represent I am authorized to make the contributions and grant the license. 
If my employer has rights to intellectual property that includes these contributions, 
I represent that I have received permission to make contributions and grant the required license on behalf of that employer.