### PR TITLE
onnxruntime provider

### DIFF
--- a/tests/neuralnet/test_onnx.py
+++ b/tests/neuralnet/test_onnx.py
@@ -52,7 +52,9 @@ def test_onnx_relu(datadir):
     def obj(mdl):
         return 1
 
-    net_regression = ort.InferenceSession(datadir.file("keras_linear_131_relu.onnx"))
+    net_regression = ort.InferenceSession(
+        datadir.file("keras_linear_131_relu.onnx"), providers=["CPUExecutionProvider"]
+    )
 
     for x in [-0.25, 0.0, 0.25, 1.5]:
         model.nn.inputs.fix(x)
@@ -93,7 +95,9 @@ def test_onnx_linear(datadir):
     def obj(mdl):
         return 1
 
-    net_regression = ort.InferenceSession(datadir.file("keras_linear_131.onnx"))
+    net_regression = ort.InferenceSession(
+        datadir.file("keras_linear_131.onnx"), providers=["CPUExecutionProvider"]
+    )
 
     for x in [-0.25, 0.0, 0.25, 1.5]:
         model.nn.inputs.fix(x)
@@ -134,7 +138,10 @@ def test_onnx_sigmoid(datadir):
     def obj(mdl):
         return 1
 
-    net_regression = ort.InferenceSession(datadir.file("keras_linear_131_sigmoid.onnx"))
+    net_regression = ort.InferenceSession(
+        datadir.file("keras_linear_131_sigmoid.onnx"),
+        providers=["CPUExecutionProvider"],
+    )
 
     for x in [-0.25, 0.0, 0.25, 1.5]:
         model.nn.inputs.fix(x)


### PR DESCRIPTION
New version of ORT requires execution provider specification when creating InferenceSession. Added 'CPUExecutionProvider'

**Legal Acknowledgement**\
By contributing to this software project, I agree my contributions are submitted under the BSD license. 
I represent I am authorized to make the contributions and grant the license. 
If my employer has rights to intellectual property that includes these contributions, 
I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
