### PR TITLE
Increase execution timeout 

### DIFF
--- a/tests/notebooks/test_run_notebooks.py
+++ b/tests/notebooks/test_run_notebooks.py
@@ -12,7 +12,7 @@ def _test_run_notebook(folder, notebook_fname, n_cells):
     # change to notebook directory to allow testing
     cwd = os.getcwd()
     os.chdir(os.path.join(this_file_dir(), "..", "..", "docs", "notebooks", folder))
-    with testbook(notebook_fname, timeout=300, execute=True) as tb:
+    with testbook(notebook_fname, timeout=500, execute=True) as tb:
         assert tb.code_cells_executed == n_cells
     os.chdir(cwd)
 

--- a/tests/notebooks/test_run_notebooks.py
+++ b/tests/notebooks/test_run_notebooks.py
@@ -9,7 +9,7 @@ from omlt.dependencies import keras_available, onnx_available
 
 # TODO: These will be replaced with stronger tests using testbook soon
 def _test_run_notebook(folder, notebook_fname, n_cells):
-    # change to notebook directory to allow testing
+    # change to notebook directory to allow for testing
     cwd = os.getcwd()
     os.chdir(os.path.join(this_file_dir(), "..", "..", "docs", "notebooks", folder))
     with testbook(notebook_fname, timeout=500, execute=True) as tb:

--- a/tests/notebooks/test_run_notebooks.py
+++ b/tests/notebooks/test_run_notebooks.py
@@ -9,7 +9,7 @@ from omlt.dependencies import keras_available, onnx_available
 
 # TODO: These will be replaced with stronger tests using testbook soon
 def _test_run_notebook(folder, notebook_fname, n_cells):
-    # change to notebook directory to allow for testing
+    # Change to notebook directory to allow for testing
     cwd = os.getcwd()
     os.chdir(os.path.join(this_file_dir(), "..", "..", "docs", "notebooks", folder))
     with testbook(notebook_fname, timeout=500, execute=True) as tb:


### PR DESCRIPTION
Increased execution timeout from 300 sec to 500 sec in notebook tests.

**Legal Acknowledgement**\
By contributing to this software project, I agree my contributions are submitted under the BSD license. 
I represent I am authorized to make the contributions and grant the license. 
If my employer has rights to intellectual property that includes these contributions, 
I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
