### PR TITLE
Fixing 404 errors of links to notebooks in the documentation

### DIFF
--- a/docs/notebooks.rst
+++ b/docs/notebooks.rst
@@ -14,7 +14,7 @@ The first set of notebooks demonstrates the basic mechanics of OMLT and shows ho
 
 * `index_handling.ipynb <https://github.com/cog-imperial/OMLT/blob/main/docs/notebooks/neuralnet/index_handling.ipynb>`_ shows how to use `IndexMapper` to handle the mappings between indexes.
 
-* `bo_with_trees.ipynb <https://github.com/cog-imperial/OMLT/blob/main/docs/notebooks/bo_with_trees.ipynb>`_ incorporates gradient-boosted trees into a Bayesian optimization loop to optimize the Rosenbrock function.
+* `bo_with_trees.ipynb <https://github.com/cog-imperial/OMLT/blob/main/docs/notebooks/trees/bo_with_trees.ipynb>`_ incorporates gradient-boosted trees into a Bayesian optimization loop to optimize the Rosenbrock function.
 
 * `linear_tree_formulations.ipynb <https://github.com/cog-imperial/OMLT/blob/main/docs/notebooks/trees/linear_tree_formulations.ipynb>`_ showcases the different linear model decision tree formulations available in OMLT.
 


### PR DESCRIPTION
I assume that the notebooks have been moved, but the documentation links did not reflect that

**Legal Acknowledgement**\
By contributing to this software project, I agree my contributions are submitted under the BSD license. 
I represent I am authorized to make the contributions and grant the license. 
If my employer has rights to intellectual property that includes these contributions, 
I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
