### PR TITLE
Bounds Handling in Linear Tree

### DIFF
--- a/src/omlt/linear_tree/lt_definition.py
+++ b/src/omlt/linear_tree/lt_definition.py
@@ -54,6 +54,7 @@ class LinearTreeDefinition:
         self.__model = lt_regressor
         self.__scaling_object = scaling_object
 
+        is_scaled = True
         # Process input bounds to insure scaled input bounds exist for formulations
         if scaled_input_bounds is None:
             if unscaled_input_bounds is not None and scaling_object is not None:
@@ -72,6 +73,7 @@ class LinearTreeDefinition:
             # input bounds = unscaled input bounds
             elif unscaled_input_bounds is not None and scaling_object is None:
                 scaled_input_bounds = unscaled_input_bounds
+                is_scaled = False
             elif unscaled_input_bounds is None:
                 raise ValueError(
                     "Input Bounds needed to represent linear trees as MIPs"
@@ -79,6 +81,7 @@ class LinearTreeDefinition:
 
         self.__unscaled_input_bounds = unscaled_input_bounds
         self.__scaled_input_bounds = scaled_input_bounds
+        self.__is_scaled = is_scaled
 
         self.__splits, self.__leaves, self.__thresholds = _parse_tree_data(
             lt_regressor, scaled_input_bounds
@@ -96,6 +99,16 @@ class LinearTreeDefinition:
     def scaled_input_bounds(self):
         """Returns dict containing scaled input bounds"""
         return self.__scaled_input_bounds
+
+    @property
+    def unscaled_input_bounds(self):
+        """Returns dict containing unscaled input bounds"""
+        return self.__unscaled_input_bounds
+
+    @property
+    def is_scaled(self):
+        """Returns bool indicating whether model is scaled"""
+        return self.__is_scaled
 
     @property
     def splits(self):


### PR DESCRIPTION
This PR is a simple change to make bounds more clear in the linear_tree formulations.. It ensures that the scaled and unscaled bounds propagate through to the Pyomo block when created.

**Legal Acknowledgement**\
By contributing to this software project, I agree my contributions are submitted under the BSD license. 
I represent I am authorized to make the contributions and grant the license. 
If my employer has rights to intellectual property that includes these contributions, 
I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
