### PR TITLE
Fix output bound calculations

### DIFF
--- a/src/omlt/linear_tree/lt_definition.py
+++ b/src/omlt/linear_tree/lt_definition.py
@@ -57,6 +57,7 @@ class LinearTreeDefinition:
         self.__model = lt_regressor
         self.__scaling_object = scaling_object
 
+        is_scaled = True
         # Process input bounds to insure scaled input bounds exist for formulations
         if scaled_input_bounds is None:
             if unscaled_input_bounds is not None and scaling_object is not None:
@@ -75,12 +76,14 @@ class LinearTreeDefinition:
             # input bounds = unscaled input bounds
             elif unscaled_input_bounds is not None and scaling_object is None:
                 scaled_input_bounds = unscaled_input_bounds
+                is_scaled = False
             elif unscaled_input_bounds is None:
                 msg = "Input Bounds needed to represent linear trees as MIPs"
                 raise ValueError(msg)
 
         self.__unscaled_input_bounds = unscaled_input_bounds
         self.__scaled_input_bounds = scaled_input_bounds
+        self.__is_scaled = is_scaled
 
         self.__splits, self.__leaves, self.__thresholds = _parse_tree_data(
             lt_regressor, scaled_input_bounds
@@ -99,6 +102,15 @@ class LinearTreeDefinition:
         """Returns dict containing scaled input bounds."""
         return self.__scaled_input_bounds
 
+    @property
+    def unscaled_input_bounds(self):
+        """Returns dict containing unscaled input bounds"""
+        return self.__unscaled_input_bounds
+
+    @property
+    def is_scaled(self):
+        """Returns bool indicating whether model is scaled"""
+        return self.__is_scaled
     @property
     def splits(self):
         """Returns dict containing split information."""

--- a/src/omlt/linear_tree/lt_definition.py
+++ b/src/omlt/linear_tree/lt_definition.py
@@ -104,12 +104,12 @@ class LinearTreeDefinition:
 
     @property
     def unscaled_input_bounds(self):
-        """Returns dict containing unscaled input bounds"""
+        """Returns dict containing unscaled input bounds."""
         return self.__unscaled_input_bounds
 
     @property
     def is_scaled(self):
-        """Returns bool indicating whether model is scaled"""
+        """Returns bool indicating whether model is scaled."""
         return self.__is_scaled
 
     @property

--- a/src/omlt/linear_tree/lt_definition.py
+++ b/src/omlt/linear_tree/lt_definition.py
@@ -111,6 +111,7 @@ class LinearTreeDefinition:
     def is_scaled(self):
         """Returns bool indicating whether model is scaled"""
         return self.__is_scaled
+
     @property
     def splits(self):
         """Returns dict containing split information."""

--- a/src/omlt/linear_tree/lt_formulation.py
+++ b/src/omlt/linear_tree/lt_formulation.py
@@ -99,11 +99,17 @@ class LinearTreeGDPFormulation(_PyomoFormulation):
             self.model_definition.scaled_input_bounds,
         )
 
+        input_vars=self.block.scaled_inputs
+        if self.model_definition.is_scaled is True:
+            output_vars = self.block.scaled_outputs
+        else:
+            output_vars = self.block.outputs
+        
         _add_gdp_formulation_to_block(
             block=self.block,
             model_definition=self.model_definition,
-            input_vars=self.block.scaled_inputs,
-            output_vars=self.block.scaled_outputs,
+            input_vars=input_vars,
+            output_vars=output_vars,
             transformation=self.transformation,
             epsilon=self.epsilon,
             include_leaf_equalities=True,
@@ -181,12 +187,16 @@ class LinearTreeHybridBigMFormulation(_PyomoFormulation):
         )
 
         input_vars = self.block.scaled_inputs
+        if self.model_definition.is_scaled is True:
+            output_vars = self.block.scaled_outputs
+        else:
+            output_vars = self.block.outputs
 
         _add_gdp_formulation_to_block(
             block=block,
             model_definition=self.model_definition,
             input_vars=input_vars,
-            output_vars=self.block.scaled_outputs,
+            output_vars=output_vars,
             transformation="custom",
             epsilon=self.epsilon,
             include_leaf_equalities=False,
@@ -285,7 +295,8 @@ def _add_gdp_formulation_to_block(  # noqa: PLR0913
             (default: True)
     """
     leaves = model_definition.leaves
-    input_bounds = model_definition.scaled_input_bounds
+    scaled_input_bounds = model_definition.scaled_input_bounds
+    unscaled_input_bounds = model_definition.unscaled_input_bounds
     n_inputs = model_definition.n_inputs
 
     # The set of leaves and the set of features
@@ -295,17 +306,23 @@ def _add_gdp_formulation_to_block(  # noqa: PLR0913
 
     # Use the input_bounds and the linear models in the leaves to calculate
     # the lower and upper bounds on the output variable. Required for Pyomo.GDP
-    output_bounds = _build_output_bounds(model_definition, input_bounds)
+    scaled_output_bounds = _build_output_bounds(model_definition, scaled_input_bounds)
+    unscaled_output_bounds = _build_output_bounds(model_definition, unscaled_input_bounds)
 
     # Ouptuts are automatically scaled based on whether inputs are scaled
-    block.outputs.setub(output_bounds[1])
-    block.outputs.setlb(output_bounds[0])
-    block.scaled_outputs.setub(output_bounds[1])
-    block.scaled_outputs.setlb(output_bounds[0])
+    block.outputs.setub(unscaled_output_bounds[1])
+    block.outputs.setlb(unscaled_output_bounds[0])
+    block.scaled_outputs.setub(scaled_output_bounds[1])
+    block.scaled_outputs.setlb(scaled_output_bounds[0])
 
-    block.intermediate_output = pe.Var(
-        tree_ids, bounds=(output_bounds[0], output_bounds[1])
-    )
+    if model_definition.is_scaled is True:
+        block.intermediate_output = pe.Var(
+            tree_ids, bounds=(scaled_output_bounds[0], scaled_output_bounds[1])
+        )
+    else:
+        block.intermediate_output = pe.Var(
+            tree_ids, bounds=(unscaled_output_bounds[0], unscaled_output_bounds[1])
+        )
 
     # Create a disjunct for each leaf containing the bound constraints
     # and the linear model expression.

--- a/src/omlt/linear_tree/lt_formulation.py
+++ b/src/omlt/linear_tree/lt_formulation.py
@@ -99,12 +99,12 @@ class LinearTreeGDPFormulation(_PyomoFormulation):
             self.model_definition.scaled_input_bounds,
         )
 
-        input_vars=self.block.scaled_inputs
+        input_vars = self.block.scaled_inputs
         if self.model_definition.is_scaled is True:
             output_vars = self.block.scaled_outputs
         else:
             output_vars = self.block.outputs
-        
+
         _add_gdp_formulation_to_block(
             block=self.block,
             model_definition=self.model_definition,
@@ -307,7 +307,9 @@ def _add_gdp_formulation_to_block(  # noqa: PLR0913
     # Use the input_bounds and the linear models in the leaves to calculate
     # the lower and upper bounds on the output variable. Required for Pyomo.GDP
     scaled_output_bounds = _build_output_bounds(model_definition, scaled_input_bounds)
-    unscaled_output_bounds = _build_output_bounds(model_definition, unscaled_input_bounds)
+    unscaled_output_bounds = _build_output_bounds(
+        model_definition, unscaled_input_bounds
+    )
 
     # Ouptuts are automatically scaled based on whether inputs are scaled
     block.outputs.setub(unscaled_output_bounds[1])

--- a/tests/linear_tree/test_lt_formulation.py
+++ b/tests/linear_tree/test_lt_formulation.py
@@ -95,13 +95,17 @@ def test_linear_tree_model_single_var():  # noqa: C901
     ltmodel_small = LinearTreeDefinition(regr_small, unscaled_input_bounds=input_bounds)
 
     scaled_input_bounds = ltmodel_small.scaled_input_bounds
+    unscaled_input_bounds = ltmodel_small.unscaled_input_bounds
     n_inputs = ltmodel_small.n_inputs
     n_outputs = ltmodel_small.n_outputs
     splits = ltmodel_small.splits
     leaves = ltmodel_small.leaves
     thresholds = ltmodel_small.thresholds
+    is_scaled = ltmodel_small.is_scaled
 
     assert scaled_input_bounds is not None
+    assert unscaled_input_bounds is not None
+    assert is_scaled == False
     assert n_inputs == 1
     assert n_outputs == 1
     # test for splits

--- a/tests/linear_tree/test_lt_formulation.py
+++ b/tests/linear_tree/test_lt_formulation.py
@@ -387,7 +387,7 @@ def test_scaling():
         Exception, match="Input Bounds needed to represent linear trees as MIPs"
     ):
         LinearTreeDefinition(regr)
-    
+
     formulation = LinearTreeHybridBigMFormulation(lt_def2)
 
     model1 = pe.ConcreteModel()
@@ -410,10 +410,10 @@ def test_scaling():
     status_1_bigm = pe.SolverFactory("scip").solve(model1, tee=True)
     pe.assert_optimal_termination(status_1_bigm)
     solution_1_bigm = (pe.value(model1.x), pe.value(model1.y))
-    y_pred = regr.predict(np.array((solution_1_bigm[0] - mean_x_small)/std_x_small).reshape(1, -1))
-    assert y_pred[0] == pytest.approx((solution_1_bigm[1] - mean_y_small)/ std_y_small)
-
-
+    y_pred = regr.predict(
+        np.array((solution_1_bigm[0] - mean_x_small) / std_x_small).reshape(1, -1)
+    )
+    assert y_pred[0] == pytest.approx((solution_1_bigm[1] - mean_y_small) / std_y_small)
 
 
 #### MULTIVARIATE INPUT TESTING ####

--- a/tests/linear_tree/test_lt_formulation.py
+++ b/tests/linear_tree/test_lt_formulation.py
@@ -105,7 +105,7 @@ def test_linear_tree_model_single_var():  # noqa: C901
 
     assert scaled_input_bounds is not None
     assert unscaled_input_bounds is not None
-    assert is_scaled == False
+    assert not is_scaled
     assert n_inputs == 1
     assert n_outputs == 1
     # test for splits


### PR DESCRIPTION
This PR is to ensure that the bounds on unscaled output vars are calculated from unscaled input bounds. Likewise, it ensures that bounds on scaled output vars are calculated from scaled input bounds

**Legal Acknowledgement**\
By contributing to this software project, I agree my contributions are submitted under the BSD license. 
I represent I am authorized to make the contributions and grant the license. 
If my employer has rights to intellectual property that includes these contributions, 
I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
