### PR TITLE
Tree surrogates with multiple outputs

### DIFF
--- a/src/omlt/formulation.py
+++ b/src/omlt/formulation.py
@@ -95,7 +95,7 @@ def scalar_or_tuple(x):
     return x
 
 
-def _setup_scaled_inputs_outputs(block, scaler=None, scaled_input_bounds=None):
+def _setup_scaled_inputs_outputs(block, scaler=None, scaled_input_bounds=None, initialize=0):
     var_factory = OmltVarFactory()
     if scaled_input_bounds is not None:
         bnds = {
@@ -103,15 +103,15 @@ def _setup_scaled_inputs_outputs(block, scaler=None, scaled_input_bounds=None):
             for k in block.inputs_set
         }
         block.scaled_inputs = var_factory.new_var(
-            block.inputs_set, initialize=0, lang=block._format, bounds=bnds
+            block.inputs_set, initialize=initialize, lang=block._format, bounds=bnds
         )
     else:
         block.scaled_inputs = var_factory.new_var(
-            block.inputs_set, initialize=0, lang=block._format
+            block.inputs_set, initialize=initialize, lang=block._format
         )
 
     block.scaled_outputs = var_factory.new_var(
-        block.outputs_set, initialize=0, lang=block._format
+        block.outputs_set, initialize=initialize, lang=block._format
     )
 
     if scaled_input_bounds is not None and scaler is None:

--- a/src/omlt/linear_tree/lt_definition.py
+++ b/src/omlt/linear_tree/lt_definition.py
@@ -90,7 +90,7 @@ class LinearTreeDefinition:
         )
 
         self.__n_inputs = _find_n_inputs(self.__leaves)
-        self.__n_outputs = 1
+        self.__n_outputs = lt_regressor[0]['models'][0].params.shape[1]
 
     @property
     def scaling_object(self):

--- a/src/omlt/linear_tree/lt_definition.py
+++ b/src/omlt/linear_tree/lt_definition.py
@@ -212,7 +212,7 @@ def _find_n_inputs(leaves):
     leaf_indices = np.array(list(leaves[tree_indices[0]].keys()))
     tree_one = tree_indices[0]
     leaf_one = leaf_indices[0]
-    return len(np.arange(0, len(leaves[tree_one][leaf_one]["slope"])))
+    return len(np.arange(0, leaves[tree_one][leaf_one]["slope"].shape[-1]))
 
 
 def _find_n_outputs(leaves):
@@ -256,7 +256,8 @@ def _reassign_none_bounds(leaves, input_bounds):
     """
     leaf_indices = np.array(list(leaves.keys()))
     leaf_one = leaf_indices[0]
-    features = np.arange(0, len(leaves[leaf_one]["slope"]))
+
+    features = np.arange(0, leaves[leaf_one]["slope"].shape[-1])
 
     for leaf in leaf_indices:
         for feat in features:
@@ -339,7 +340,7 @@ def _parse_tree_data(model, input_bounds):  # noqa: C901, PLR0915, PLR0912
     # keys in the splits dictionary
     for leaf in leaves:
         del splits[leaf]
-        leaves[leaf]["slope"] = list(leaves[leaf]["models"].coef_)
+        leaves[leaf]["slope"] = leaves[leaf]["models"].coef_
         leaves[leaf]["intercept"] = leaves[leaf]["models"].intercept_
 
     # This loop creates an parent node id entry for each node in the tree

--- a/src/omlt/linear_tree/lt_definition.py
+++ b/src/omlt/linear_tree/lt_definition.py
@@ -90,7 +90,20 @@ class LinearTreeDefinition:
         )
 
         self.__n_inputs = _find_n_inputs(self.__leaves)
-        self.__n_outputs = lt_regressor[0]['models'][0].params.shape[1]
+
+        # get one of the models
+        if isinstance(lt_regressor, dict):
+            example_model = lt_regressor[0]['models'][0]
+        elif isinstance(lt_regressor, lineartree.lineartree.LinearTreeRegressor):
+            example_model = lt_regressor.summary()[0]["models"][0]
+        else:
+            msg = "Model entry must be dict or linear-tree instance"
+            raise TypeError(msg)
+
+        if hasattr(example_model.intercept_, "__len__") > 1:
+            self.__n_outputs = len(example_model.intercept_)
+        else:
+            self.__n_outputs = 1
 
     @property
     def scaling_object(self):

--- a/src/omlt/linear_tree/lt_definition.py
+++ b/src/omlt/linear_tree/lt_definition.py
@@ -212,7 +212,7 @@ def _find_n_inputs(leaves):
     leaf_indices = np.array(list(leaves[tree_indices[0]].keys()))
     tree_one = tree_indices[0]
     leaf_one = leaf_indices[0]
-    return len(np.arange(0, leaves[tree_one][leaf_one]["slope"].shape[-1]))
+    return leaves[tree_one][leaf_one]["slope"].shape[-1]
 
 
 def _find_n_outputs(leaves):
@@ -411,7 +411,7 @@ def _parse_tree_data(model, input_bounds):  # noqa: C901, PLR0915, PLR0912
         leaves[leaf]["bounds"] = {}
 
     leaf_ids = np.array(list(leaves.keys()))
-    features = np.arange(0, len(leaves[leaf_ids[0]]["slope"]))
+    features = np.arange(0, leaves[leaf_ids[0]]["slope"].shape[-1])
 
     # For each feature in each leaf, initialize lower and upper bounds to None
     for feat in features:

--- a/src/omlt/linear_tree/lt_definition.py
+++ b/src/omlt/linear_tree/lt_definition.py
@@ -90,20 +90,7 @@ class LinearTreeDefinition:
         )
 
         self.__n_inputs = _find_n_inputs(self.__leaves)
-
-        # get one of the models
-        if isinstance(lt_regressor, dict):
-            example_model = lt_regressor[0]['models'][0]
-        elif isinstance(lt_regressor, lineartree.lineartree.LinearTreeRegressor):
-            example_model = lt_regressor.summary()[0]["models"][0]
-        else:
-            msg = "Model entry must be dict or linear-tree instance"
-            raise TypeError(msg)
-
-        if hasattr(example_model.intercept_, "__len__") > 1:
-            self.__n_outputs = len(example_model.intercept_)
-        else:
-            self.__n_outputs = 1
+        self.__n_outputs = _find_n_outputs(self.__leaves)
 
     @property
     def scaling_object(self):
@@ -226,6 +213,31 @@ def _find_n_inputs(leaves):
     tree_one = tree_indices[0]
     leaf_one = leaf_indices[0]
     return len(np.arange(0, len(leaves[tree_one][leaf_one]["slope"])))
+
+
+def _find_n_outputs(leaves):
+    """Find n outputs.
+
+    Finds the number of outputs using the length of the intercept vector in the
+    first leaf
+
+    Arguments:
+        leaves: Dictionary of leaf information
+
+    Returns:
+        Number of outputs
+    """
+    tree_indices = np.array(list(leaves.keys()))
+    leaf_indices = np.array(list(leaves[tree_indices[0]].keys()))
+    tree_one = tree_indices[0]
+    leaf_one = leaf_indices[0]
+
+    intercept = leaves[tree_one][leaf_one]["intercept"]
+
+    if hasattr(intercept, "__len__"):
+        return len(intercept)
+    else:
+        return 1
 
 
 def _reassign_none_bounds(leaves, input_bounds):

--- a/src/omlt/linear_tree/lt_formulation.py
+++ b/src/omlt/linear_tree/lt_formulation.py
@@ -402,7 +402,7 @@ def _add_gdp_formulation_to_block(  # noqa: PLR0913
             if slope.ndim == 1:
                 slope = slope.reshape(-1, 1)
 
-            if isinstance(intercept, float):
+            if isinstance(intercept, (int, float, np.number)):
                 intercept = np.array([intercept])
 
             dsj.linear_exp = pe.ConstraintList()

--- a/src/omlt/linear_tree/lt_formulation.py
+++ b/src/omlt/linear_tree/lt_formulation.py
@@ -292,7 +292,7 @@ def _build_output_bounds(model_def, input_bounds):
                 bounds[output_idx, 1] = max(bounds[output_idx, 1], upper_bound)
                 bounds[output_idx, 0] = min(bounds[output_idx, 0], lower_bound)
 
-    return bounds.T
+    return bounds
 
 
 def _add_gdp_formulation_to_block(  # noqa: PLR0913
@@ -343,16 +343,16 @@ def _add_gdp_formulation_to_block(  # noqa: PLR0913
 
     # Outputs are automatically scaled based on whether inputs are scaled
     for output_idx in output_indices:
-        block.outputs[output_idx].setub(unscaled_output_bounds[1, output_idx])
-        block.outputs[output_idx].setlb(unscaled_output_bounds[0, output_idx])
-        block.scaled_outputs[output_idx].setub(scaled_output_bounds[1, output_idx])
-        block.scaled_outputs[output_idx].setlb(scaled_output_bounds[0, output_idx])
+        block.outputs[output_idx].setub(unscaled_output_bounds[output_idx, 1])
+        block.outputs[output_idx].setlb(unscaled_output_bounds[output_idx, 0])
+        block.scaled_outputs[output_idx].setub(scaled_output_bounds[output_idx, 1])
+        block.scaled_outputs[output_idx].setlb(scaled_output_bounds[output_idx, 0])
 
     # Find the maximum and minimum bounds for the output variable
-    max_unscaled_output = np.max(unscaled_output_bounds[1])
-    min_unscaled_output = np.min(unscaled_output_bounds[0])
-    max_scaled_output = np.max(scaled_output_bounds[1])
-    min_scaled_output = np.min(scaled_output_bounds[0])
+    max_unscaled_output = np.max(unscaled_output_bounds[:, 1])
+    min_unscaled_output = np.min(unscaled_output_bounds[:, 0])
+    max_scaled_output = np.max(scaled_output_bounds[:, 1])
+    min_scaled_output = np.min(scaled_output_bounds[:, 0])
 
     if model_definition.is_scaled is True:
         block.intermediate_output = pe.Var(set_index, bounds = (min_scaled_output, max_scaled_output))

--- a/src/omlt/linear_tree/lt_formulation.py
+++ b/src/omlt/linear_tree/lt_formulation.py
@@ -249,7 +249,7 @@ class LinearTreeHybridBigMFormulation(_PyomoFormulation):
                 return block.intermediate_output[tree, output_idx] == sum(
                 (
                     sum(
-                    leaves[tree][leaf]["slope"][feat][output_idx] * input_vars[feat]
+                    leaves[tree][leaf]["slope"][output_idx][feat] * input_vars[feat]
                     for feat in features
                     )
                     + leaves[tree][leaf]["intercept"][output_idx]
@@ -284,7 +284,7 @@ def _build_output_bounds(model_def, input_bounds):
 
     for tree in leaves:
         for leaf in leaves[tree]:
-            slopes = leaves[tree][leaf]["slope"]
+            slopes = leaves[tree][leaf]["slope"].T
             intercept = leaves[tree][leaf]["intercept"]
 
             # Make sure slopes and intercept have at least 2 and 1 dimensions
@@ -394,7 +394,7 @@ def _add_gdp_formulation_to_block(  # noqa: PLR0913
         dsj.ub_constraint = pe.Constraint(features, rule=ub_rule)
 
         if include_leaf_equalities:
-            slope = leaves[tree][leaf]["slope"]
+            slope = leaves[tree][leaf]["slope"].T
             intercept = leaves[tree][leaf]["intercept"]
 
             # Make sure slopes and intercept have at least 2 and 1 dimensions

--- a/src/omlt/linear_tree/lt_formulation.py
+++ b/src/omlt/linear_tree/lt_formulation.py
@@ -266,6 +266,14 @@ def _build_output_bounds(model_def, input_bounds):
             slopes = leaves[tree][leaf]["slope"]
             intercept = leaves[tree][leaf]["intercept"]
 
+            # Make sure slopes and intercept have at least 2 and 1 dimensions
+            slopes = np.array(slopes)  # Ensure slopes is a numpy array
+            if slopes.ndim == 1:
+                slopes = slopes.reshape(-1, 1)
+
+            if isinstance(intercept, float):
+                intercept = np.array([intercept])
+
             # Compute bounds for each output
             for output_idx in range(n_outputs):
                 upper_bound = 0
@@ -367,6 +375,15 @@ def _add_gdp_formulation_to_block(  # noqa: PLR0913
         if include_leaf_equalities:
             slope = leaves[tree][leaf]["slope"]
             intercept = leaves[tree][leaf]["intercept"]
+
+            # Make sure slopes and intercept have at least 2 and 1 dimensions
+            slope = np.array(slope)  # Ensure slope is a numpy array
+            if slope.ndim == 1:
+                slope = slope.reshape(-1, 1)
+
+            if isinstance(intercept, float):
+                intercept = np.array([intercept])
+
             dsj.linear_exp = pe.ConstraintList()
             for output_idx in output_indices:
                 dsj.linear_exp.add(

--- a/tests/linear_tree/test_lt_formulation.py
+++ b/tests/linear_tree/test_lt_formulation.py
@@ -870,3 +870,136 @@ def test_raise_exception_for_wrong_transformation():
         match="Supported transformations are: bigm, mbigm, hull, and custom",
     ):
         LinearTreeGDPFormulation(model_def, transformation="hello")
+
+
+#### MULTIVARIATE OUTPUT TESTING ####
+
+
+@pytest.mark.skipif(not lineartree_available, reason="Need Linear-Tree Package")
+def test_linear_tree_model_multi_output():
+    X = np.array(
+        [
+            [4.98534526, 1.8977914],
+            [4.38751717, 4.48456528],
+            [2.65451539, 2.44426211],
+            [3.32761277, 4.58757063],
+            [0.36806515, 0.82428634],
+            [4.16036314, 1.09680059],
+            [2.29025371, 0.72246559],
+            [1.92725929, 0.34359974],
+            [4.02101578, 1.39448628],
+            [3.28019501, 1.22160752],
+            [2.73026047, 3.9482306],
+            [0.45621172, 0.56130164],
+            [2.64296795, 4.75411397],
+            [4.72526084, 3.35223772],
+            [2.39270941, 4.41622262],
+            [4.42707908, 0.35276571],
+            [1.58452501, 3.28957671],
+            [0.20009184, 2.90255483],
+            [4.36453075, 3.61985047],
+            [1.05576503, 2.57532169],
+        ]
+    )
+
+    Y = np.array(
+        [
+            [10.23341638],
+            [4.00860872],
+            [3.85046103],
+            [9.48457266],
+            [6.36974536],
+            [3.19763555],
+            [4.78390803],
+            [1.51994021],
+            [3.18768132],
+            [3.7972809],
+            [7.93779383],
+            [3.46714285],
+            [7.89435163],
+            [10.62832561],
+            [1.50713442],
+            [7.44321537],
+            [9.39437373],
+            [4.38891182],
+            [1.32105126],
+            [3.37287403],
+        ]
+    )
+
+    # Stack Y and X horizontally to create a 2D array
+    Y = np.hstack((Y, X))
+
+    # construct a LinearTreeDefinition
+    regr = linear_model_tree(X=X, y=Y)
+    input_bounds = {0: (min(X[:,0]), max(X[:,0])), 1: (min(X[:,1]), max(X[:,1]))}
+    ltmodel_small = LinearTreeDefinition(regr, unscaled_input_bounds=input_bounds)
+
+    scaled_input_bounds = ltmodel_small.scaled_input_bounds
+    n_inputs = ltmodel_small.n_inputs
+    n_outputs = ltmodel_small.n_outputs
+    splits = ltmodel_small.splits
+    leaves = ltmodel_small.leaves
+    thresholds = ltmodel_small.thresholds
+
+    # assert attributes in LinearTreeDefinition
+    assert scaled_input_bounds is not None
+    assert n_inputs == 2
+    assert n_outputs == 3
+
+    # test for splits
+    # assert the number of splits
+    assert len(splits[0].keys()) == NUM_SPLITS
+    splits_key_list = [
+        "col",
+        "th",
+        "loss",
+        "samples",
+        "parent",
+        "children",
+        "models",
+        "left_leaves",
+        "right_leaves",
+        "y_index",
+    ]
+    # assert whether all the dicts have such keys
+    for i in splits[0]:
+        for key in splits[0][i]:
+            assert key in splits_key_list
+    # test for leaves
+    # assert the number of leaves
+    assert len(leaves[0].keys()) == NUM_LEAVES
+    # assert whether all the dicts have such keys
+    leaves_key_list = [
+        "loss",
+        "samples",
+        "models",
+        "slope",
+        "intercept",
+        "parent",
+        "bounds",
+    ]
+    for j in leaves[0]:
+        for key in leaves[0][j]:
+            assert key in leaves_key_list
+            # if the key is slope, test the shape of it
+            if key == "slope":
+                assert leaves[0][j][key].shape[-1] == n_inputs
+            # elif the key is bounds, test the lb <= ub
+            elif key == "bounds":
+                features = leaves[0][j][key].keys()
+                for k in range(len(features)):
+                    lb = leaves[0][j][key][k][0]
+                    ub = leaves[0][j][key][k][1]
+                    # there is chance that don't have lb and ub at this step
+                    if lb is not None and ub is not None:
+                        assert lb <= ub
+    # test for thresholds
+    # assert whether each feature has threshold
+    assert len(thresholds[0].keys()) == n_inputs
+    # assert the number of thresholds
+    thresholds_count = 0
+    for k in range(len(thresholds[0].keys())):
+        for _ in range(len(thresholds[0][k].keys())):
+            thresholds_count += 1
+    assert thresholds_count == len(splits[0].keys())

--- a/tests/linear_tree/test_lt_formulation.py
+++ b/tests/linear_tree/test_lt_formulation.py
@@ -874,65 +874,65 @@ def test_raise_exception_for_wrong_transformation():
 
 #### MULTIVARIATE OUTPUT TESTING ####
 
+X_multi = np.array(
+    [
+        [4.98534526, 1.8977914],
+        [4.38751717, 4.48456528],
+        [2.65451539, 2.44426211],
+        [3.32761277, 4.58757063],
+        [0.36806515, 0.82428634],
+        [4.16036314, 1.09680059],
+        [2.29025371, 0.72246559],
+        [1.92725929, 0.34359974],
+        [4.02101578, 1.39448628],
+        [3.28019501, 1.22160752],
+        [2.73026047, 3.9482306],
+        [0.45621172, 0.56130164],
+        [2.64296795, 4.75411397],
+        [4.72526084, 3.35223772],
+        [2.39270941, 4.41622262],
+        [4.42707908, 0.35276571],
+        [1.58452501, 3.28957671],
+        [0.20009184, 2.90255483],
+        [4.36453075, 3.61985047],
+        [1.05576503, 2.57532169],
+    ]
+)
+
+Y_multi = np.array(
+    [
+        [10.23341638],
+        [4.00860872],
+        [3.85046103],
+        [9.48457266],
+        [6.36974536],
+        [3.19763555],
+        [4.78390803],
+        [1.51994021],
+        [3.18768132],
+        [3.7972809],
+        [7.93779383],
+        [3.46714285],
+        [7.89435163],
+        [10.62832561],
+        [1.50713442],
+        [7.44321537],
+        [9.39437373],
+        [4.38891182],
+        [1.32105126],
+        [3.37287403],
+    ]
+)
+
+# Stack Y and X horizontally to create a 2D array
+Y_multi = np.hstack((Y_multi, X_multi))
+
 
 @pytest.mark.skipif(not lineartree_available, reason="Need Linear-Tree Package")
 def test_linear_tree_model_multi_output():
-    X = np.array(
-        [
-            [4.98534526, 1.8977914],
-            [4.38751717, 4.48456528],
-            [2.65451539, 2.44426211],
-            [3.32761277, 4.58757063],
-            [0.36806515, 0.82428634],
-            [4.16036314, 1.09680059],
-            [2.29025371, 0.72246559],
-            [1.92725929, 0.34359974],
-            [4.02101578, 1.39448628],
-            [3.28019501, 1.22160752],
-            [2.73026047, 3.9482306],
-            [0.45621172, 0.56130164],
-            [2.64296795, 4.75411397],
-            [4.72526084, 3.35223772],
-            [2.39270941, 4.41622262],
-            [4.42707908, 0.35276571],
-            [1.58452501, 3.28957671],
-            [0.20009184, 2.90255483],
-            [4.36453075, 3.61985047],
-            [1.05576503, 2.57532169],
-        ]
-    )
-
-    Y = np.array(
-        [
-            [10.23341638],
-            [4.00860872],
-            [3.85046103],
-            [9.48457266],
-            [6.36974536],
-            [3.19763555],
-            [4.78390803],
-            [1.51994021],
-            [3.18768132],
-            [3.7972809],
-            [7.93779383],
-            [3.46714285],
-            [7.89435163],
-            [10.62832561],
-            [1.50713442],
-            [7.44321537],
-            [9.39437373],
-            [4.38891182],
-            [1.32105126],
-            [3.37287403],
-        ]
-    )
-
-    # Stack Y and X horizontally to create a 2D array
-    Y = np.hstack((Y, X))
-
     # construct a LinearTreeDefinition
-    regr = linear_model_tree(X=X, y=Y)
-    input_bounds = {0: (min(X[:,0]), max(X[:,0])), 1: (min(X[:,1]), max(X[:,1]))}
+    regr = linear_model_tree(X=X_multi, y=Y_multi)
+    input_bounds = {0: (min(X_multi[:,0]), max(X_multi[:,0])), 1: (min(X_multi[:,1]), max(X_multi[:,1]))}
     ltmodel_small = LinearTreeDefinition(regr, unscaled_input_bounds=input_bounds)
 
     scaled_input_bounds = ltmodel_small.scaled_input_bounds
@@ -1003,3 +1003,184 @@ def test_linear_tree_model_multi_output():
         for _ in range(len(thresholds[0][k].keys())):
             thresholds_count += 1
     assert thresholds_count == len(splits[0].keys())
+
+@pytest.mark.skipif(
+    not lineartree_available or not cbc_available,
+    reason="Need Linear-Tree Package and cbc",
+)
+def test_bigm_formulation_multi_output():
+    regr = linear_model_tree(X=X_multi, y=Y_multi)
+    input_bounds = {0: (min(X_multi[:, 0]), max(X_multi[:, 0])), 1: (min(X_multi[:, 1]), max(X_multi[:, 1]))}
+    ltmodel_small = LinearTreeDefinition(regr, unscaled_input_bounds=input_bounds)
+    formulation1_lt = LinearTreeGDPFormulation(ltmodel_small, transformation="bigm")
+
+    model1 = pe.ConcreteModel()
+    model1.x0 = pe.Var(initialize=0)
+    model1.x1 = pe.Var(initialize=0)
+    model1.y = pe.Var(initialize=0)
+    model1.obj = pe.Objective(expr=1)
+    model1.lt = OmltBlock()
+    model1.lt.build_formulation(formulation1_lt)
+
+    @model1.Constraint()
+    def connect_input1(mdl):
+        return mdl.x0 == mdl.lt.inputs[0]
+
+    @model1.Constraint()
+    def connect_input2(mdl):
+        return mdl.x1 == mdl.lt.inputs[1]
+
+    @model1.Constraint()
+    def connect_outputs(mdl):
+        return mdl.y == mdl.lt.outputs[0]
+
+    model1.x0.fix(0.5)
+    model1.x1.fix(0.8)
+
+    status_1_bigm = pe.SolverFactory("cbc").solve(model1, tee=True)
+    pe.assert_optimal_termination(status_1_bigm)
+    solution_1_bigm = pe.value(model1.y)
+    y_pred = regr.predict(
+        np.array([pe.value(model1.x0), pe.value(model1.x1)]).reshape(1, -1)
+    )
+    assert y_pred[0, 0] == pytest.approx(solution_1_bigm)
+
+
+@pytest.mark.skipif(
+    not lineartree_available or not cbc_available,
+    reason="Need Linear-Tree Package and cbc",
+)
+def test_hull_formulation_multi_output():
+    regr = linear_model_tree(X=X_multi, y=Y_multi)
+    input_bounds = {0: (min(X_multi[:, 0]), max(X_multi[:, 0])), 1: (min(X_multi[:, 1]), max(X_multi[:, 1]))}
+    ltmodel_small = LinearTreeDefinition(regr, unscaled_input_bounds=input_bounds)
+    formulation1_lt = LinearTreeGDPFormulation(ltmodel_small, transformation="hull")
+
+    model1 = pe.ConcreteModel()
+    model1.x0 = pe.Var(initialize=0)
+    model1.x1 = pe.Var(initialize=0)
+    model1.y = pe.Var(initialize=0)
+    model1.obj = pe.Objective(expr=1)
+    model1.lt = OmltBlock()
+    model1.lt.build_formulation(formulation1_lt)
+
+    @model1.Constraint()
+    def connect_input1(mdl):
+        return mdl.x0 == mdl.lt.inputs[0]
+
+    @model1.Constraint()
+    def connect_input2(mdl):
+        return mdl.x1 == mdl.lt.inputs[1]
+
+    @model1.Constraint()
+    def connect_outputs(mdl):
+        return mdl.y == mdl.lt.outputs[0]
+
+    model1.x0.fix(0.5)
+    model1.x1.fix(0.8)
+
+    status_1_bigm = pe.SolverFactory("cbc").solve(model1, tee=True)
+    pe.assert_optimal_termination(status_1_bigm)
+    solution_1_bigm = pe.value(model1.y)
+    y_pred = regr.predict(
+        np.array([pe.value(model1.x0), pe.value(model1.x1)]).reshape(1, -1)
+    )
+    assert y_pred[0,0] == pytest.approx(solution_1_bigm)
+
+
+@pytest.mark.skipif(
+    not lineartree_available or not gurobi_available,
+    reason="Need Linear-Tree Package and gurobi",
+)
+def test_mbigm_formulation_multi_output():
+    regr = linear_model_tree(X=X_multi, y=Y_multi)
+    input_bounds = {0: (min(X_multi[:, 0]), max(X_multi[:, 0])), 1: (min(X_multi[:, 1]), max(X_multi[:, 1]))}
+    ltmodel_small = LinearTreeDefinition(regr, unscaled_input_bounds=input_bounds)
+    formulation1_lt = LinearTreeGDPFormulation(ltmodel_small, transformation="mbigm")
+
+    model1 = pe.ConcreteModel()
+    model1.x0 = pe.Var(initialize=0)
+    model1.x1 = pe.Var(initialize=0)
+    model1.y = pe.Var(initialize=0)
+    model1.obj = pe.Objective(expr=1)
+    model1.lt = OmltBlock()
+    model1.lt.build_formulation(formulation1_lt)
+
+    @model1.Constraint()
+    def connect_input1(mdl):
+        return mdl.x0 == mdl.lt.inputs[0]
+
+    @model1.Constraint()
+    def connect_input2(mdl):
+        return mdl.x1 == mdl.lt.inputs[1]
+
+    @model1.Constraint()
+    def connect_outputs(mdl):
+        return mdl.y == mdl.lt.outputs[0]
+
+    model1.x0.fix(0.5)
+    model1.x1.fix(0.8)
+
+    status_1_bigm = pe.SolverFactory("gurobi").solve(model1, tee=True)
+    pe.assert_optimal_termination(status_1_bigm)
+    solution_1_bigm = pe.value(model1.y)
+    y_pred = regr.predict(
+        np.array([pe.value(model1.x0), pe.value(model1.x1)]).reshape(1, -1)
+    )
+    assert y_pred[0,0] == pytest.approx(solution_1_bigm)
+
+
+@pytest.mark.skipif(
+    not lineartree_available or not scip_available,
+    reason="Need Linear-Tree Package and scip",
+)
+def test_hybrid_bigm_formulation_multi_output():
+    regr = linear_model_tree(X=X_multi, y=Y_multi)
+    input_bounds = {0: (min(X_multi[:, 0]), max(X_multi[:, 0])), 1: (min(X_multi[:, 1]), max(X_multi[:, 1]))}
+    ltmodel_small = LinearTreeDefinition(regr, unscaled_input_bounds=input_bounds)
+    formulation1_lt = LinearTreeHybridBigMFormulation(ltmodel_small)
+
+    model1 = pe.ConcreteModel()
+    model1.x0 = pe.Var(initialize=0)
+    model1.x1 = pe.Var(initialize=0)
+    model1.y = pe.Var(initialize=0)
+    model1.obj = pe.Objective(expr=1)
+    model1.lt = OmltBlock()
+    model1.lt.build_formulation(formulation1_lt)
+
+    num_constraints = 0
+    var_set = ComponentSet()
+    for cons in model1.lt.component_data_objects(pe.Constraint, active=True):
+        num_constraints += 1
+        for v in identify_variables(cons.expr):
+            var_set.add(v)
+
+    num_leaves = len(ltmodel_small.leaves[0])
+    # binary for each leaf + some more from the formulation
+    assert len(var_set) == num_leaves + 13
+    # 2 bounds constraints for each input, the xor, the output constraint, and
+    # four scaling constraints from OMLT
+    assert num_constraints == 16
+
+    @model1.Constraint()
+    def connect_input1(mdl):
+        return mdl.x0 == mdl.lt.inputs[0]
+
+    @model1.Constraint()
+    def connect_input2(mdl):
+        return mdl.x1 == mdl.lt.inputs[1]
+
+    @model1.Constraint()
+    def connect_outputs(mdl):
+        return mdl.y == mdl.lt.outputs[0]
+
+    model1.x0.fix(0.5)
+    model1.x1.fix(0.8)
+
+    status_1_bigm = pe.SolverFactory("scip").solve(model1, tee=True)
+    pe.assert_optimal_termination(status_1_bigm)
+    solution_1_bigm = pe.value(model1.y)
+    y_pred = regr.predict(
+        np.array([pe.value(model1.x0), pe.value(model1.x1)]).reshape(1, -1)
+    )
+    assert y_pred[0, 0] == pytest.approx(solution_1_bigm)


### PR DESCRIPTION
I had a need for tree surrogates with multiple outputs and OMLT did not support them. I have updated the LMDT definition and formulations to enable this. I have added some tests for this feature as well.

This should be better than using multiple different trees on the same input space for different labels/targets/outputs. 

It is compatible with the linear-tree package and the systems2atoms hyperplane trees that I have also been working on. 

**Legal Acknowledgement**\
By contributing to this software project, I agree my contributions are submitted under the BSD license. 
I represent I am authorized to make the contributions and grant the license. 
If my employer has rights to intellectual property that includes these contributions, 
I represent that I have received permission to make contributions and grant the required license on behalf of that employer.