### PR TITLE
Tree surrogates with multiple outputs (#176)

### DIFF
--- a/src/omlt/formulation.py
+++ b/src/omlt/formulation.py
@@ -95,7 +95,9 @@ def scalar_or_tuple(x):
     return x
 
 
-def _setup_scaled_inputs_outputs(block, scaler=None, scaled_input_bounds=None):
+def _setup_scaled_inputs_outputs(
+    block, scaler=None, scaled_input_bounds=None, initialize=0
+):
     var_factory = OmltVarFactory()
     if scaled_input_bounds is not None:
         bnds = {
@@ -103,15 +105,15 @@ def _setup_scaled_inputs_outputs(block, scaler=None, scaled_input_bounds=None):
             for k in block.inputs_set
         }
         block.scaled_inputs = var_factory.new_var(
-            block.inputs_set, initialize=0, lang=block._format, bounds=bnds
+            block.inputs_set, initialize=initialize, lang=block._format, bounds=bnds
         )
     else:
         block.scaled_inputs = var_factory.new_var(
-            block.inputs_set, initialize=0, lang=block._format
+            block.inputs_set, initialize=initialize, lang=block._format
         )
 
     block.scaled_outputs = var_factory.new_var(
-        block.outputs_set, initialize=0, lang=block._format
+        block.outputs_set, initialize=initialize, lang=block._format
     )
 
     if scaled_input_bounds is not None and scaler is None:

--- a/src/omlt/linear_tree/lt_definition.py
+++ b/src/omlt/linear_tree/lt_definition.py
@@ -100,7 +100,7 @@ class LinearTreeDefinition:
         )
 
         self.__n_inputs = _find_n_inputs(self.__leaves)
-        self.__n_outputs = 1
+        self.__n_outputs = _find_n_outputs(self.__leaves)
 
     @property
     def scaling_object(self):
@@ -222,7 +222,31 @@ def _find_n_inputs(leaves):
     leaf_indices = np.array(list(leaves[tree_indices[0]].keys()))
     tree_one = tree_indices[0]
     leaf_one = leaf_indices[0]
-    return len(np.arange(0, len(leaves[tree_one][leaf_one]["slope"])))
+    return leaves[tree_one][leaf_one]["slope"].shape[-1]
+
+
+def _find_n_outputs(leaves):
+    """Find n outputs.
+
+    Finds the number of outputs using the length of the intercept vector in the
+    first leaf
+
+    Arguments:
+        leaves: Dictionary of leaf information
+
+    Returns:
+        Number of outputs
+    """
+    tree_indices = np.array(list(leaves.keys()))
+    leaf_indices = np.array(list(leaves[tree_indices[0]].keys()))
+    tree_one = tree_indices[0]
+    leaf_one = leaf_indices[0]
+
+    intercept = leaves[tree_one][leaf_one]["intercept"]
+
+    if hasattr(intercept, "__len__"):
+        return len(intercept)
+    return 1
 
 
 def _reassign_none_bounds(leaves, input_bounds):
@@ -241,7 +265,8 @@ def _reassign_none_bounds(leaves, input_bounds):
     """
     leaf_indices = np.array(list(leaves.keys()))
     leaf_one = leaf_indices[0]
-    features = np.arange(0, len(leaves[leaf_one]["slope"]))
+
+    features = np.arange(0, leaves[leaf_one]["slope"].shape[-1])
 
     for leaf in leaf_indices:
         for feat in features:
@@ -324,7 +349,7 @@ def _parse_tree_data(model, input_bounds):  # noqa: C901, PLR0915, PLR0912
     # keys in the splits dictionary
     for leaf in leaves:
         del splits[leaf]
-        leaves[leaf]["slope"] = list(leaves[leaf]["models"].coef_)
+        leaves[leaf]["slope"] = leaves[leaf]["models"].coef_
         leaves[leaf]["intercept"] = leaves[leaf]["models"].intercept_
 
     # This loop creates an parent node id entry for each node in the tree
@@ -395,7 +420,7 @@ def _parse_tree_data(model, input_bounds):  # noqa: C901, PLR0915, PLR0912
         leaves[leaf]["bounds"] = {}
 
     leaf_ids = np.array(list(leaves.keys()))
-    features = np.arange(0, len(leaves[leaf_ids[0]]["slope"]))
+    features = np.arange(0, leaves[leaf_ids[0]]["slope"].shape[-1])
 
     # For each feature in each leaf, initialize lower and upper bounds to None
     for feat in features:


### PR DESCRIPTION
I had a need for tree surrogates with multiple outputs and OMLT did not support them. I have updated the LMDT definition and formulations to enable this. I have added some tests for this feature as well.

This should be better than using multiple different trees on the same input space for different targets/outputs.

It is compatible with the linear-tree package and the systems2atoms hyperplane trees that I have also been working on.

Addresses issue #161 which is a request for this feature!

**Legal Acknowledgement**\
By contributing to this software project, I agree my contributions are submitted under the BSD license.
I represent I am authorized to make the contributions and grant the license.
If my employer has rights to intellectual property that includes these contributions,
I represent that I have received permission to make contributions and grant the required license on behalf of that employer.

**Legal Acknowledgement**\
By contributing to this software project, I agree my contributions are submitted under the BSD license. 
I represent I am authorized to make the contributions and grant the license. 
If my employer has rights to intellectual property that includes these contributions, 
I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
